### PR TITLE
1.0.1 bug fix regarding none-existing tag

### DIFF
--- a/update-local-nuget-cache/Program.cs
+++ b/update-local-nuget-cache/Program.cs
@@ -11,7 +11,7 @@ namespace update_local_nuget_cache
         {
             if (args.Length < 3)
             {
-                Console.WriteLine("Syntax error\nShould be called like this:\nupdate-local-nuget-cache $(ProjectPath) $(OutputPath) $(ProjectName)");
+                Console.WriteLine("* Syntax error\nShould be called like this:\nupdate-local-nuget-cache $(ProjectPath) $(OutputPath) $(ProjectName)");
                 return 1;
             }
 
@@ -25,7 +25,8 @@ namespace update_local_nuget_cache
             var csProjXml = XElement.Load(projectPath);
 
             // we get it like this since other property groups might exist with similar elements like version
-            var propertyGroup = csProjXml.Descendants("OutputType").First().Parent;
+
+            var propertyGroup = csProjXml.Descendants("TargetFramework").First().Parent;
             var targetFramework = propertyGroup.Element("TargetFramework")?.Value;
             var version = "";
             var packageId = "";

--- a/update-local-nuget-cache/reinstall.bat
+++ b/update-local-nuget-cache/reinstall.bat
@@ -1,0 +1,3 @@
+dotnet tool uninstall -g update-local-nuget-cache
+dotnet tool install --global --add-source nupkg update-local-nuget-cache
+pause

--- a/update-local-nuget-cache/update-local-nuget-cache.csproj
+++ b/update-local-nuget-cache/update-local-nuget-cache.csproj
@@ -11,6 +11,11 @@
     <Authors>Geeks ltd</Authors>
     <Company>Geeks ltd</Company>
     <PackageId>update-local-nuget-cache</PackageId>
+    <Version>1.0.1</Version>
+    <Description>updates the local nuget cache for easier development</Description>
+    <Copyright>Geeks ltd</Copyright>
+    <PackageProjectUrl>https://github.com/geeksltd/update-local-nuget-cache</PackageProjectUrl>
+    <PackageReleaseNotes>- Fixed an issue were a tag which might not exist in all project was being searched for to find to property group in the .csproj file</PackageReleaseNotes>
     
   </PropertyGroup>
 


### PR DESCRIPTION
To find the property group containing the framework supported, I was looking for a tag which might not exist in all projects. changed it to the <TargetFramework> which exists in all projects