### PR TITLE
fixed teh version selection bug

### DIFF
--- a/update-local-nuget-cache/Program.cs
+++ b/update-local-nuget-cache/Program.cs
@@ -52,7 +52,12 @@ namespace update_local_nuget_cache
 
             var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             var nuGetCache = userProfile + "\\.nuget\\packages\\";
-            var packageFolder = nuGetCache + packageId + "\\" + version + "\\lib\\" + targetFramework;
+            var packageTopFolder = nuGetCache + packageId;
+            var list = Directory.GetDirectories(packageTopFolder).Select(x => Path.GetDirectoryName(x)).ToList();
+            list.Sort();
+            if (list.Count > 0)
+                version = list[list.Count - 1];
+            var packageFolder = packageTopFolder + "\\" + version + "\\lib\\" + targetFramework;
 
             if (!Directory.Exists(packageFolder))
             {

--- a/update-local-nuget-cache/Program.cs
+++ b/update-local-nuget-cache/Program.cs
@@ -53,10 +53,18 @@ namespace update_local_nuget_cache
             var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             var nuGetCache = userProfile + "\\.nuget\\packages\\";
             var packageTopFolder = nuGetCache + packageId;
-            var list = Directory.GetDirectories(packageTopFolder).Select(x => Path.GetDirectoryName(x)).ToList();
-            list.Sort();
-            if (list.Count > 0)
-                version = list[list.Count - 1];
+            //if we have different versions of the package
+            //let's find the latest and put the files in it
+            if (Directory.Exists(packageTopFolder))
+            {
+                //GetFileName gets the last part of the path which here will be directory names
+                var list = Directory.GetDirectories(packageTopFolder).Select(x => Path.GetFileName(x)).ToList();
+                //we sort the names so we get the latest one easily
+                list.Sort();
+                if (list.Count > 0)
+                    version = list[list.Count - 1];
+            }
+
             var packageFolder = packageTopFolder + "\\" + version + "\\lib\\" + targetFramework;
 
             if (!Directory.Exists(packageFolder))

--- a/update-local-nuget-cache/update-local-nuget-cache.csproj
+++ b/update-local-nuget-cache/update-local-nuget-cache.csproj
@@ -11,11 +11,12 @@
     <Authors>Geeks ltd</Authors>
     <Company>Geeks ltd</Company>
     <PackageId>update-local-nuget-cache</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Description>updates the local nuget cache for easier development</Description>
     <Copyright>Geeks ltd</Copyright>
     <PackageProjectUrl>https://github.com/geeksltd/update-local-nuget-cache</PackageProjectUrl>
-    <PackageReleaseNotes>- Fixed an issue were a tag which might not exist in all project was being searched for to find to property group in the .csproj file</PackageReleaseNotes>
+    <PackageReleaseNotes>- Previously , only if the directory of the same version existed, that one would get replaced, now the latest version of each package is replaced instead of the version which is being built</PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/geeksltd/update-local-nuget-cache</RepositoryUrl>
     
   </PropertyGroup>
 


### PR DESCRIPTION
Fixed the logic so instead of replacing the exact version of the package which is being built in the cache, it replaces the latest which exist in the cache.